### PR TITLE
Add option to filter select values

### DIFF
--- a/app/views/fields/enum/_form.html.erb
+++ b/app/views/fields/enum/_form.html.erb
@@ -21,9 +21,7 @@ By default, the input is a select field for the enum attributes.
   <%= f.select(
   field.attribute,
   options_for_select(
-    f.object.class.public_send(field.attribute.to_s.pluralize).map do |k, v|
-      [I18n.t("activerecord.attributes.#{f.object.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{k}", default: k.humanize), k]
-    end,
+    field.filtered_options(f.object.class.public_send(field.attribute.to_s.pluralize)),
     f.object.public_send(field.attribute.to_s)
   ),
   { include_blank: false },

--- a/lib/administrate/field/enum.rb
+++ b/lib/administrate/field/enum.rb
@@ -12,6 +12,16 @@ module Administrate
         options[:html] || {}
       end
 
+      def option_filter
+        options[:option_filter] || Proc.new { true }
+      end
+
+      def filtered_options(options)
+        options.select(&option_filter).map do |k, v|
+          [I18n.t("activerecord.attributes.#{resource.class.name.underscore}.#{attribute.to_s.pluralize}.#{k}", default: k.humanize), k]
+        end
+      end
+
       class Engine < ::Rails::Engine
       end
     end

--- a/spec/lib/administrate/field/enum_spec.rb
+++ b/spec/lib/administrate/field/enum_spec.rb
@@ -32,4 +32,34 @@ describe Administrate::Field::Enum do
       expect(field.html_options[:class]).to be_nil
     end
   end
+
+  describe '#option_filter' do
+    it 'returns a supplied option_filter Proc' do
+      page = :form
+      option_filter = Proc.new { |option| option != 'x' }
+      field = Administrate::Field::Enum.with_options(option_filter: option_filter)
+                                       .new(:status, 'status', page)
+
+      expect(field.option_filter).to eq(option_filter)
+    end
+
+    it 'returns a no-op filter Proc by default' do
+      page = :form
+      field = Administrate::Field::Enum.new(:status, 'status', page)
+
+      expect(field.evaluator.call).to be_truthy
+    end
+  end
+
+  describe '#filtered_options' do
+    it 'returns array of filtered arrays' do
+      page = :form
+      options = ['I', 'Am', 'Groot']
+      option_filter = Proc.new { |option| option != 'Am' }
+      field = Administrate::Field::Enum.with_options(option_filter: option_filter)
+                                       .new(:status, 'status', page)
+
+      expect(field.filtered_options(options)).to eq([['I', 'I'], ['Groot', 'Groot']])
+    end
+  end
 end


### PR DESCRIPTION
#### Why?
We had the need to restrict certain enum values from the dropdown select form

#### Changes
- Added `option_filter` which returns either a no-op filter proc by default or a filter proc that evaluates and filters the provided options and & `filtered_options` to return the new select options array 
- Updated form.erb to use `filtered_options`